### PR TITLE
Add reciprocal watchtower support

### DIFF
--- a/templates/lnd-sample.conf
+++ b/templates/lnd-sample.conf
@@ -29,6 +29,16 @@ bitcoin.defaultchanconfs=2
 
 <neutrino-peers>
 
+; Enable watchtower to watch my other node
+; Emable Watchtower
+[watchtower]
+watchtower.active=1
+
+; activate watchtower client so we can get get other servers
+; to make sure noone steals our money
+[wtclient]
+wtclient.active=1
+
 [tor]
 tor.active=1
 tor.control=<tor-proxy-ip>:<tor-control-port>


### PR DESCRIPTION
Something that Umbrel omitted before and may be useful for ensuring we all play nice (don't trust, verify) is watchtower support for lightning.

The purpose of the configuration is to merely enable it for CLI (advanced) use.